### PR TITLE
macos 10.7 with more recent versions of curl and git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vagrant
 *.retry
+.DS_Store

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -32,6 +32,10 @@ Vagrant.configure("2") do |config|
     freebsd12.vm.box = "generic/freebsd12"
   end
 
+  config.vm.define "macos14" do |macos14|
+    macos14.vm.box = "yzgyyang/macOS-10.14"
+  end
+
   config.vm.define "macos7" do |macos7|
     macos7.vm.box = "tuupola/osx-lion-10.7-xcode"
     $script = <<-SCRIPT
@@ -52,7 +56,7 @@ Vagrant.configure("2") do |config|
       brew install --build-from-source git;
       brew update;
     SCRIPT
-    macos7.vm.provision "bootstrap", type: "shell", preserve_order: true, privileged: false, inline: $script
+    macos7.vm.provision "bootstrap", type: "shell", privileged: false, inline: $script
   end
 
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -34,10 +34,12 @@ Vagrant.configure("2") do |config|
 
   config.vm.define "macos14" do |macos14|
     macos14.vm.box = "yzgyyang/macOS-10.14"
+    macos14.vm.synced_folder ".", "/vagrant", disabled: true
   end
 
   config.vm.define "macos7" do |macos7|
     macos7.vm.box = "tuupola/osx-lion-10.7-xcode"
+    macos7.vm.synced_folder ".", "/vagrant", disabled: true
     $script = <<-SCRIPT
       [ ! -f /etc/paths.orig ] \
         && sudo sed -i.orig '1s;^;/usr/local/sbin\'$'\n;' /etc/paths \

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -32,6 +32,28 @@ Vagrant.configure("2") do |config|
     freebsd12.vm.box = "generic/freebsd12"
   end
 
+  config.vm.define "macos7" do |macos7|
+    macos7.vm.box = "tuupola/osx-lion-10.7-xcode"
+    $script = <<-SCRIPT
+      [ ! -f /etc/paths.orig ] \
+        && sudo sed -i.orig '1s;^;/usr/local/sbin\'$'\n;' /etc/paths \
+        && sudo sed -i.edit1 '1s;^;/usr/local/bin\'$'\n;' /etc/paths \
+        && PATH="/usr/local/bin:/usr/local/sbin::${PATH}" \
+        && export PATH;
+      [ ! -f /usr/local/bin/brew ] && ruby \
+        -e "$(curl -fsSkL raw.github.com/mistydemeo/tigerbrew/go/install)" \
+        </dev/null \
+      || echo "Tigerbrew is already installed...";
+      brew doctor </dev/null;
+      brew install curl && brew link --force curl || \
+        echo "!!!! Something went wrong during install of curl, retrying... !!!!!" \
+        && brew install curl && brew link --force curl \
+        || echo "!!!! Unable to install curl !!!!!";
+      brew install --build-from-source git;
+      brew update;
+    SCRIPT
+    macos7.vm.provision "bootstrap", type: "shell", preserve_order: true, privileged: false, inline: $script
+  end
 
 
   config.vm.provider "virtualbox" do |vb|

--- a/tasks/macos.yml
+++ b/tasks/macos.yml
@@ -1,0 +1,11 @@
+- name: Install packages
+  hombrew:
+    name: [
+      cmake, git,
+    ]
+  pip:
+    executable: pip
+    name: pytest
+  pip:
+    executable: pip3
+    name: pytest

--- a/tasks/macos.yml
+++ b/tasks/macos.yml
@@ -1,11 +1,17 @@
 - name: Install packages
-  hombrew:
+  homebrew:
     name: [
-      cmake, git,
+      cmake, git, python@2, python
     ]
+- name: Install pytest in Python 2.7
   pip:
-    executable: pip
+    executable: /usr/local/bin/pip
     name: pytest
+- name: Install pytest in Python 3.7
   pip:
-    executable: pip3
+    executable: /usr/local/bin/pip3
     name: pytest
+- name: Creating user builder with password builder
+  user:
+    name: builder
+    password: builder

--- a/vagrant-playbook.yml
+++ b/vagrant-playbook.yml
@@ -10,6 +10,9 @@
   - include_tasks: tasks/freebsd.yml
     when: ansible_system == "FreeBSD"
 
+  - include_tasks: tasks/macos.yml
+    when: ansible_system == "Darwin"
+
   handlers:
   - name: Perform reboot (Windows)
     listen: reboot


### PR DESCRIPTION
This is an initial macos 10.7 box with more *recent* versions of `curl` and `git` to avoid SSL/TLS version issues.